### PR TITLE
Metadata type 33 is not defined?

### DIFF
--- a/src/LuaMidi/Constants.lua
+++ b/src/LuaMidi/Constants.lua
@@ -28,8 +28,10 @@ local Constants = {
    META_END_OF_TRACK_ID   = {0x2F, 0x00},
    PROGRAM_CHANGE_STATUS  = 0xC0,
    NOTES                  = {},
-   METADATA_TYPES = {"Text","Copyright","Name","Instrument","Lyric","Marker","Cue Point",
-      [81] = "Tempo",[88] = "Time Signature",[89] = "Key Signature"}
+   METADATA_TYPES = {
+      "Text","Copyright","Name","Instrument","Lyric","Marker","Cue Point",
+      [33] = "Midi Port", [81] = "Tempo",[88] = "Time Signature",[89] = "Key Signature"
+   }
 }
 
 local table_notes = {

--- a/src/LuaMidi/Constants.lua
+++ b/src/LuaMidi/Constants.lua
@@ -30,7 +30,8 @@ local Constants = {
    NOTES                  = {},
    METADATA_TYPES = {
       "Text","Copyright","Name","Instrument","Lyric","Marker","Cue Point",
-      [33] = "Midi Port", [81] = "Tempo",[88] = "Time Signature",[89] = "Key Signature"
+      [33] = "Midi Port", [81] = "Tempo", 
+      [84] = "SMPTE Offset", [88] = "Time Signature",[89] = "Key Signature"
    }
 }
 


### PR DESCRIPTION
Metadata type 33 or "Midi Port" acording to this website -> https://mido.readthedocs.io/en/1.1.24/meta_message_types.html <- was not defined in Constants.METADATA_TYPES. Loading a midi file that uses the metadata type 33 causes the program to fail with the error "Table index is nil". Is there a reason why these other types are not defined?